### PR TITLE
Secure ngrok config with env variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ htmlcov/
 
 # Ngrok
 auth_token
+ngrok.yml
 
 # Notion sync
 *.ics

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Notion Synch
+
+This project provides a small Flask service that converts Notion calendar data to ICS format.
+
+## Environment Variables
+
+- `NOTION_API_KEY`: Token for accessing the Notion API.
+- `DATABASE_ID`: ID of the Notion database to read events from.
+- `PORT`: Port the Flask application runs on (default: `5004`).
+- `NGROK_AUTH_TOKEN`: Authentication token used by Ngrok to create secure tunnels. When using Ngrok, export this variable so the value can be injected into `ngrok.yml`.
+
+## Ngrok
+
+The `ngrok.yml` file contains Ngrok configuration and should not be committed with your secret token. The file is included in `.gitignore`. When running Ngrok you can supply your token via the `NGROK_AUTH_TOKEN` environment variable.

--- a/ngrok.yml
+++ b/ngrok.yml
@@ -1,2 +1,2 @@
-echo "version: 2
-authtoken: 2xHa2nUw9t5uqfwEcXz6WIeTjOb_5Au6iGLv1TM3PaTvjnGqK" > ngrok.yml
+version: 2
+authtoken: ${NGROK_AUTH_TOKEN}


### PR DESCRIPTION
## Summary
- replace the hard-coded token in `ngrok.yml` with `${NGROK_AUTH_TOKEN}`
- ignore `ngrok.yml`
- document the new variable in `README.md`

## Testing
- `python3 -m py_compile notion_to_ics.py wsgi.py`


------
https://chatgpt.com/codex/tasks/task_e_684561d95cbc83248cf4d15432322434