### PR TITLE
Add configurable LOG_PATH for notion_to_ics

### DIFF
--- a/notion_to_ics.py
+++ b/notion_to_ics.py
@@ -9,19 +9,23 @@ from dotenv import load_dotenv
 import json
 from flask_cors import CORS
 
+# Load environment variables from .env file before configuring logging
+load_dotenv()
+
+# Determine log file path
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+LOG_PATH = os.getenv("LOG_PATH", os.path.join(BASE_DIR, "app.log"))
+
 # Configure logging to show both in console and file
 logging.basicConfig(
     level=logging.DEBUG,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     handlers=[
         logging.StreamHandler(sys.stdout),
-        logging.FileHandler('/home/neinron/src/app.log')
+        logging.FileHandler(LOG_PATH)
     ]
 )
 logger = logging.getLogger(__name__)
-
-# Load environment variables from .env file
-load_dotenv()
 
 # Get environment variables
 NOTION_API_KEY = os.getenv("NOTION_API_KEY")


### PR DESCRIPTION
## Summary
- support configuring the log file path via `LOG_PATH`
- default to `app.log` inside the project directory

## Testing
- `python -m py_compile notion_to_ics.py`

------
https://chatgpt.com/codex/tasks/task_e_684561de38508324b17d0ec5d2d4f48a