### PR TITLE
Add GitHub webhook updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,42 @@ This project provides a small Flask service that converts Notion calendar data t
 
 The `ngrok.yml` file contains Ngrok configuration and should not be committed with your secret token. The file is included in `.gitignore`. When running Ngrok you can supply your token via the `NGROK_AUTH_TOKEN` environment variable.
 
+
+## Using Git on PythonAnywhere
+
+PythonAnywhere consoles include common source control tools like Git, so you can manage repositories directly from the web interface. If you want to clone a private GitHub repo, generate a key on PythonAnywhere and add the public part to your GitHub account:
+
+```bash
+ssh-keygen
+cat ~/.ssh/id_rsa.pub
+```
+
+Free accounts may only access a limited set of sites over HTTP/HTTPS or the pure `git` protocol. For repositories hosted on services such as GitHub or Bitbucket, make sure you use HTTPS URLs. GitHub requires a personal access token when pushing over HTTPS.
+
+For more details, see the PythonAnywhere help page on using external version control.
+
+## Automating Updates on PythonAnywhere
+
+To automatically pull new code and reload your web app whenever you push to GitHub,
+use the `update_webhook.py` script included in this repository.
+
+1. **Add the webhook route**
+   Configure your PythonAnywhere WSGI file to use the webhook app:
+
+   ```python
+   from update_webhook import app as application
+   ```
+
+2. **Set environment variables**
+   - `GITHUB_WEBHOOK_SECRET`: secret token configured in your GitHub webhook.
+   - `WSGI_FILE`: path to your PythonAnywhere WSGI file (defaults to
+     `/var/www/yourusername_pythonanywhere_com_wsgi.py`).
+
+3. **Create a GitHub webhook**
+   - Payload URL: `https://<your-username>.pythonanywhere.com/update`
+   - Content type: `application/json`
+   - Secret: same value as `GITHUB_WEBHOOK_SECRET`
+   - Trigger: “Just the push event.”
+
+Whenever GitHub sends the webhook, PythonAnywhere will `git pull` the repository
+and touch the WSGI file, causing the app to reload with the latest code.

--- a/update_webhook.py
+++ b/update_webhook.py
@@ -1,0 +1,40 @@
+import hmac
+import hashlib
+import os
+import subprocess
+from flask import Flask, request, abort
+
+app = Flask(__name__)
+
+# Secret token configured in GitHub webhook settings
+GITHUB_SECRET = os.environ.get("GITHUB_WEBHOOK_SECRET", "").encode()
+
+# Path to this repository and WSGI file used by PythonAnywhere
+REPO_PATH = os.path.dirname(os.path.abspath(__file__))
+WSGI_FILE = os.path.expanduser(os.environ.get(
+    "WSGI_FILE",
+    "/var/www/yourusername_pythonanywhere_com_wsgi.py"
+))
+
+@app.route("/update", methods=["POST"])
+def update():
+    """Pull the latest code and reload the app when GitHub sends a push webhook."""
+    header_signature = request.headers.get("X-Hub-Signature-256")
+    if not header_signature or "=" not in header_signature:
+        abort(403)
+
+    sha_name, signature = header_signature.split("=")
+    if sha_name != "sha256":
+        abort(501)
+
+    mac = hmac.new(GITHUB_SECRET, msg=request.data, digestmod=hashlib.sha256)
+    if not hmac.compare_digest(mac.hexdigest(), signature):
+        abort(403)
+
+    subprocess.call(["git", "-C", REPO_PATH, "pull"])  # Update repo
+    subprocess.call(["touch", WSGI_FILE])  # Trigger app reload
+
+    return "Updated", 200
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
## Summary
- add `update_webhook.py` for GitHub-triggered reload on PythonAnywhere
- document how to use the webhook script

## Testing
- `python -m py_compile notion_to_ics.py wsgi.py update_webhook.py`


------
https://chatgpt.com/codex/tasks/task_e_684563e926788324bf167281141c5af3